### PR TITLE
gema jekyll-seo-tag para mejorar SEO

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source "https://rubygems.org"
 ruby RUBY_VERSION
 
 gem "jekyll", "3.2.1"
+gem 'jekyll-seo-tag'
+

--- a/_config.yml
+++ b/_config.yml
@@ -1,9 +1,19 @@
 title: Sevilla Developers User Group
 description: The landing page for Sevilla Developers User Group
 url: "http://sevilladevelopers.github.io"
+image: "http://sevilladevelopers.github.io/assets/img/sevilla-developers-icon.png"
+
+#SEO
+twitter:
+  username: SevillaDevelope
+facebook:
+ publisher: sevilladevelopers
 
 # Google Analytics Code
 codega: UA-96791038-1
+
+gems:
+  - jekyll-seo-tag
 
 # Build settings
 markdown: kramdown
@@ -13,3 +23,8 @@ exclude: ['README.md', 'CNAME', 'Gemfile', 'Gemfile.lock', 'package.json', 'asse
 sass:
   sass_dir: assets/css
   style: :compressed
+
+
+
+
+

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,6 +4,7 @@
 <!--[if IE 8]>         <html class="no-js lt-ie9" lang=""> <![endif]-->
 <!--[if gt IE 8]><!--> <html class="no-js" lang=""> <!--<![endif]-->
 {% include head.html %}
+{% seo %}
 
   <body id="top">
     {% include nav.html %}


### PR DESCRIPTION
Añadido y configurado el plugin de Jekyll https://github.com/jekyll/jekyll-seo-tag que añade metadata para SEO y redes sociales.